### PR TITLE
ENH: try OpenMP in SetEffectiveMigration

### DIFF
--- a/VGsim/_BirthDeath.pyx
+++ b/VGsim/_BirthDeath.pyx
@@ -3,6 +3,7 @@
 # distutils: language = c++
 
 cimport cython
+from cython.parallel import prange
 
 from libc.math cimport log, floor, abs
 from libcpp.vector cimport vector
@@ -185,9 +186,11 @@ cdef class BirthDeathModel:
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef void SetEffectiveMigration(self):
+        cdef Py_ssize_t i, j
+
         for i in range(self.popNum):
             self.pm_maxEffectiveMigration[i] = 0.0
-        for i in range(self.popNum):
+        for i in prange(self.popNum, nogil=True):
             for j in range(self.popNum):
                 self.pm_effectiveMigration[i,j] = self.pm_migrationRates[i,j]*self.pm.contactDensity[j]/self.pm.sizes[j]+self.pm_migrationRates[j,i]*self.pm.contactDensity[i]/self.pm.sizes[i]
                 if self.pm_effectiveMigration[i,j] > self.pm_maxEffectiveMigration[j]:
@@ -497,7 +500,7 @@ cdef class BirthDeathModel:
         for j in range(0, iterations):
             self.SampleTime()
             popId = self.GenerateEvent()
-            if self.totalRate == 0.0 or self.pm.globalInfectious == 0:
+            if self.totalRate == 0.0 or self.pm.globalInfectious == 0 or self.events.ptr == 20000000:
                 break
             self.CheckLockdown(popId)
         print("Total number of iterations: ", self.events.ptr)

--- a/VGsim/setup.py
+++ b/VGsim/setup.py
@@ -2,11 +2,18 @@ from setuptools import setup
 
 from Cython.Compiler import Options
 
+import sys
 import numpy
 
 Options.annotate = True
 
 PACKAGE_NAME = 'VGsim'
+
+# enable openMP on linux, disable on MacOS
+if sys.platform == "darwin":
+    openmp_args = []
+else:
+    openmp_args = ['-fopenmp']
 
 
 def configuration(parent_package='', top_path=None):
@@ -20,8 +27,8 @@ def configuration(parent_package='', top_path=None):
                                   'models.pxi', 'fast_choose.pxi'],
                          language='c++',
                          include_dirs=[numpy.get_include()],
-                         extra_compile_args=['-fopenmp'],
-                         extra_link_args=['-fopenmp'],
+                         extra_compile_args=openmp_args,
+                         extra_link_args=openmp_args,
     )
 
     return config

--- a/VGsim/setup.py
+++ b/VGsim/setup.py
@@ -20,6 +20,8 @@ def configuration(parent_package='', top_path=None):
                                   'models.pxi', 'fast_choose.pxi'],
                          language='c++',
                          include_dirs=[numpy.get_include()],
+                         extra_compile_args=['-fopenmp'],
+                         extra_link_args=['-fopenmp'],
     )
 
     return config


### PR DESCRIPTION
Do NOT merge : note the artificial cap on the number of iterations!

Try OpenMP-ing the double loop. Locally, it does spawn the number of threads = the number of cores. The time gain is very much sublinear, but non-negligible either. So should investigate before deciding if it's worth it. 

Also, MacOS and OpenMP. ATM, parallelization is simply disabled on a Mac.