### PR TITLE
BLD: pin meson==0.59.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,10 @@
 [build-system]
 requires  = [
     "wheel",
-    "meson",
+    "meson==0.59.2",
     "mesonpep517",
     "ninja",
-    "mc_lib @ git+http://github.com/ev-br/mc_lib.git@v0.3",
-    "matplotlib",
-    "prettytable"
+    "mc_lib @ git+http://github.com/ev-br/mc_lib.git@v0.3.1"
 ]
 
 build-backend = "mesonpep517.buildapi"
@@ -30,7 +28,7 @@ classifiers = [
 
 requires  = [
     "numpy>=1.19.5",
-    "mc_lib @ git+http://github.com/ev-br/mc_lib.git@v0.3",
+    "mc_lib @ git+http://github.com/ev-br/mc_lib.git@v0.3.1",
     "prettytable",
     "matplotlib",
     "pytest"


### PR DESCRIPTION
Something broke down with 0.60 release, so pin 0.59.2, also in mc_lib v0.3.1

Also clean up the build-requirements while I'm at it. @spirinvadim 