### PR TITLE
BLD: unpin meson, add numpy & cython to build-deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [build-system]
 requires  = [
     "wheel",
-    "meson==0.60.3",
+    "meson>=0.60.3",
     "mesonpep517",
     "ninja",
-    "mc_lib @ git+http://github.com/ev-br/mc_lib.git@v0.4"
+    "numpy>=1.19.5",
+    "Cython>=0.29.18",
+    "mc_lib @ git+http://github.com/ev-br/mc_lib.git@v0.4.1"
 ]
 
 build-backend = "mesonpep517.buildapi"
@@ -28,7 +30,7 @@ classifiers = [
 
 requires  = [
     "numpy>=1.19.5",
-    "mc_lib @ git+http://github.com/ev-br/mc_lib.git@v0.4",
+    "mc_lib @ git+http://github.com/ev-br/mc_lib.git@v0.4.1",
     "prettytable",
     "matplotlib",
     "pytest"


### PR DESCRIPTION
- numpy & cython were (probably?) installed via mc_lib, which seems brittle and is not self-explanatory. 
- unpin the exact meson version, >=0.60.3 seems to work
- bump the mc_lib version to 0.4.1 (this is a purely cosmetic change)